### PR TITLE
fix: allow override of certs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ minikube_version: 0.17.1
 minikube_checksum: "sha256:54f9e24b5622f540a6d5edd7450ce546cf6f57f9feff21fd5d92d0d2f552ac31"
 minikube_download_url: http://storage.googleapis.com/minikube/releases/v
 docker_api_version: 1.23
+minikube_validate_certs: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,5 +7,6 @@
     mode: 0755
     owner: root
     group: root
+    validate_certs: "{{minikube_validate_certs}}"
   become: true
 


### PR DESCRIPTION
Allow override to ignore certificate check on minikube download as this fails when behind Proxies